### PR TITLE
"$ID_LIKE"=debian

### DIFF
--- a/elabctl.sh
+++ b/elabctl.sh
@@ -60,7 +60,7 @@ function backup()
 
 function getDeps()
 {
-    if [ "$ID" == "ubuntu" ] || [ "$ID" == "debian" ]; then
+    if [ "$ID" == "ubuntu" ] || [ "$ID" == "debian" ] || [ "$ID_LIKE" == "debian" ]; then
         echo "Synchronizing packages index. Please wait…"
         apt-get update >> $LOG_FILE 2>&1
     fi
@@ -104,7 +104,7 @@ function getDistrib()
         # pacman = package manager
 
         # DEBIAN / UBUNTU
-        if [ "$ID" == "ubuntu" ] || [ "$ID" == "debian" ]; then
+        if [ "$ID" == "ubuntu" ] || [ "$ID" == "debian" ] || [ "$ID_LIKE" == "debian" ]; then
             PACMAN="apt-get -y install"
 
         # FEDORA


### PR DESCRIPTION
Allows for debian based operating systems with different IDs in /etc/os-release to be recognised.