### PR TITLE
Split CentOS/RedHat into two inside getDistrib

### DIFF
--- a/elabctl.sh
+++ b/elabctl.sh
@@ -116,14 +116,18 @@ function getDistrib()
         elif [ "$ID" == "fedora" ]; then
             PACMAN="dnf -y install"
 
-        # RED HAT / CENTOS
-        elif [ "$ID" == "centos" ] || [ "$ID" == "rhel" ]; then
+        # CENTOS
+        elif [ "$ID" == "centos" ]; then
             PACMAN="yum -y install"
             # we need this to install python-pip
             wget -q http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-8.noarch.rpm -O /tmp/epel.rpm
             # add || true because if it's already installed the exit value is 1
             rpm -ivh /tmp/epel.rpm || true
-
+        
+        # RED HAT
+        elif [ "$ID" == "rhel" ]; then
+            PACMAN="yum -y install"
+        
         # ARCH IS THE BEST
         elif [ "$ID" == "arch" ]; then
             PACMAN="pacman -Sy --noconfirm"


### PR DESCRIPTION
On RedHat 7.3, the install script fails, but with the split it works