### PR TITLE
Update elabctl.sh

### DIFF
--- a/elabctl.sh
+++ b/elabctl.sh
@@ -120,9 +120,10 @@ function getDistrib()
         elif [ "$ID" == "centos" ]; then
             PACMAN="yum -y install"
             # we need this to install python-pip
-            wget -q http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-8.noarch.rpm -O /tmp/epel.rpm
+            #wget -q http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-8.noarch.rpm -O /tmp/epel.rpm
             # add || true because if it's already installed the exit value is 1
-            rpm -ivh /tmp/epel.rpm || true
+            #rpm -ivh /tmp/epel.rpm || true
+            yum -y install epel-release || true
 
         # RED HAT
         elif [ "$ID" == "rhel" ]; then


### PR DESCRIPTION
Install the package for the epel repository directly from the CentOS repository with yum. That way the installation will select the appropriate repository. Currently, if the version change then the script will not find the appropriate rpm and will fail with out telling anything that could help to solve the problem. The yum install epel-release command will always work. 

Tested on:
NAME="CentOS Linux"
VERSION="7 (Core)"
ID="centos"
ID_LIKE="rhel fedora"
VERSION_ID="7"
PRETTY_NAME="CentOS Linux 7 (Core)"
ANSI_COLOR="0;31"
CPE_NAME="cpe:/o:centos:centos:7"
HOME_URL="https://www.centos.org/"
BUG_REPORT_URL="https://bugs.centos.org/"

CENTOS_MANTISBT_PROJECT="CentOS-7"
CENTOS_MANTISBT_PROJECT_VERSION="7"
REDHAT_SUPPORT_PRODUCT="centos"
REDHAT_SUPPORT_PRODUCT_VERSION="7"