### PR TITLE
Draft: List version in backup ZIP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog for elabctl
 
+## Version 2.3.5
+
+* Add an elabftw.yml.versioned file. If a user wants to restore from backup to the same eLabFTW version, they can use this. It does not replace elabftw.yml, since this might break the expected behaviour of future runs of `elabctl update`.
+
+
 ## Version 2.3.4
 
 * Remove `--column-statistics=0` to mysqldump command. See https://github.com/elabftw/elabctl/issues/23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for elabctl
 
+## Version 2.3.4
+
+* Remove `--column-statistics=0` to mysqldump command. See https://github.com/elabftw/elabctl/issues/23
+
 ## Version 2.3.3
 
 * Add `--column-statistics=0` to mysqldump command.

--- a/elabctl.sh
+++ b/elabctl.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # https://www.elabftw.net
-declare -r ELABCTL_VERSION='2.3.4'
+declare -r ELABCTL_VERSION='2.3.5'
 
 # default backup dir
 declare BACKUP_DIR='/var/backups/elabftw'

--- a/elabctl.sh
+++ b/elabctl.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # https://www.elabftw.net
-declare -r ELABCTL_VERSION='2.3.3'
+declare -r ELABCTL_VERSION='2.3.4'
 
 # default backup dir
 declare BACKUP_DIR='/var/backups/elabftw'
@@ -55,7 +55,7 @@ function backup
     local -r dumpfile="${BACKUP_DIR}/mysql_dump-${date}.sql"
 
     # dump sql
-    docker exec "${ELAB_MYSQL_CONTAINER_NAME}" bash -c 'mysqldump -u$MYSQL_USER -p$MYSQL_PASSWORD -r dump.sql --no-tablespaces --column-statistics=0 $MYSQL_DATABASE 2>&1 | grep -v "Warning: Using a password"' || echo ">> Containers must be running to do the backup!"
+    docker exec "${ELAB_MYSQL_CONTAINER_NAME}" bash -c 'mysqldump -u$MYSQL_USER -p$MYSQL_PASSWORD -r dump.sql --no-tablespaces $MYSQL_DATABASE 2>&1 | grep -v "Warning: Using a password"' || echo ">> Containers must be running to do the backup!"
     # copy it from the container to the host
     docker cp "${ELAB_MYSQL_CONTAINER_NAME}":dump.sql "$dumpfile"
     # compress it to the max
@@ -418,7 +418,7 @@ function mysql-backup
     local -r dumpfile="${BACKUP_DIR}/mysql_dump-${date}.sql"
 
     # dump sql
-    docker exec "${ELAB_MYSQL_CONTAINER_NAME}" bash -c 'mysqldump -u$MYSQL_USER -p$MYSQL_PASSWORD -r dump.sql --no-tablespaces --column-statistics=0 $MYSQL_DATABASE 2>&1 | grep -v "Warning: Using a password"' || echo ">> Containers must be running to do the backup!"
+    docker exec "${ELAB_MYSQL_CONTAINER_NAME}" bash -c 'mysqldump -u$MYSQL_USER -p$MYSQL_PASSWORD -r dump.sql --no-tablespaces $MYSQL_DATABASE 2>&1 | grep -v "Warning: Using a password"' || echo ">> Containers must be running to do the backup!"
     # copy it from the container to the host
     docker cp "${ELAB_MYSQL_CONTAINER_NAME}:dump.sql" "$dumpfile"
     # compress it to the max

--- a/elabctl.sh
+++ b/elabctl.sh
@@ -62,9 +62,17 @@ function backup
     gzip -f --best "$dumpfile"
     # make a zip of the uploads folder
     zip -rq "$zipfile" ${DATA_DIR}/web -x ${DATA_DIR}/web/tmp\*
-    # add the config file
+    
+    # Add the config file.
     zip -rq "$zipfile" $CONF_FILE
 
+    # Add a config file with current version.
+    # Replace elabftw.yml with this if the SQL schema may have changed
+    # between backup and restore time.
+    VERSION=`docker exec elabftw bash -c 'echo $ELABFTW_VERSION'`
+    sed s/'image: elabftw\/elabimg:.*$'/"image: elabftw\/elabimg:$VERSION"/ "$CONF_FILE" > "$CONF_FILE.versioned"
+    zip -rq "$zipfile" "$CONF_FILE.versioned"
+    
     echo "Done. Copy ${BACKUP_DIR} over to another computer."
 }
 

--- a/elabctl.sh
+++ b/elabctl.sh
@@ -69,7 +69,7 @@ function backup
     # Add a config file with current version.
     # Replace elabftw.yml with this if the SQL schema may have changed
     # between backup and restore time.
-    VERSION=`docker exec elabftw bash -c 'echo $ELABFTW_VERSION'`
+    VERSION=`docker exec ${ELAB_WEB_CONTAINER_NAME} bash -c 'echo $ELABFTW_VERSION'`
     sed s/'image: elabftw\/elabimg:.*$'/"image: elabftw\/elabimg:$VERSION"/ "$CONF_FILE" > "$CONF_FILE.versioned"
     zip -rq "$zipfile" "$CONF_FILE.versioned"
     

--- a/elabctl.sh
+++ b/elabctl.sh
@@ -40,7 +40,7 @@ function backup
 {
     echo "Using backup directory $BACKUP_DIR"
 
-    if ! ls -A "${BACKUP_DIR}" > /dev/null 2>&1; then
+    if [ ! -d "${BACKUP_DIR}" ]; then
         mkdir -pv "${BACKUP_DIR}"
         if [ $? -eq 1 ]; then
             sudo mkdir -pv ${BACKUP_DIR}
@@ -404,7 +404,7 @@ function mysql
 # create a mysqldump and a zip archive of the uploaded files
 function mysql-backup
 {
-    if ! ls -A "${BACKUP_DIR}" > /dev/null 2>&1; then
+    if [ ! -d "${BACKUP_DIR}" ]; then
         mkdir -pv "${BACKUP_DIR}"
         if [ $? -eq 1 ]; then
             sudo mkdir -pv ${BACKUP_DIR}


### PR DESCRIPTION
The idea is that if the system is restored from a backup, it should get a somewhat faithful recreation of the system. Currently, the elabftw.yml will likely contain the image elabftw/elabimg:latest. This hack saves a copy with current version hard-coded instead. Restoring from backup should thus get a container that works with the SQL dump in the backup (which it might not if the elabftw/elabimg:latest code expects some other schema, or wants a superset of the current config to work reliably and securely).

The current pull request does not change the standard elabftw.yml file, but rather adds a copy.