### PR TITLE
Add .versioned backup to elabctl. Bump version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for elabctl
 
+## Version 2.3.4
+
+* Add an elabftw.yml.versioned file. If a user wants to restore from backup to the same eLabFTW version, they can use this. It does not replace elabftw.yml, since this might break the expected behaviour of future runs of `elabctl update`.
+
 ## Version 2.3.3
 
 * Add `--column-statistics=0` to mysqldump command.

--- a/elabctl.sh
+++ b/elabctl.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # https://www.elabftw.net
-declare -r ELABCTL_VERSION='2.3.3'
+declare -r ELABCTL_VERSION='2.3.4'
 
 # default backup dir
 declare BACKUP_DIR='/var/backups/elabftw'
@@ -65,6 +65,13 @@ function backup
     # add the config file
     zip -rq "$zipfile" $CONF_FILE
 
+    # Add a config file with current version.
+    # Replace elabftw.yml with this if the SQL schema may have changed
+    # between backup and restore time.
+    VERSION=`docker exec ${ELAB_WEB_CONTAINER_NAME} bash -c 'echo $ELABFTW_VERSION'`
+    sed s/'image: elabftw\/elabimg:.*$'/"image: elabftw\/elabimg:$VERSION"/ "$CONF_FILE" > "$CONF_FILE.versioned"
+    zip -rq "$zipfile" "$CONF_FILE.versioned"
+    
     echo "Done. Copy ${BACKUP_DIR} over to another computer."
 }
 

--- a/elabctl.sh
+++ b/elabctl.sh
@@ -68,8 +68,8 @@ function backup
     # Add a config file with current version.
     # Replace elabftw.yml with this if the SQL schema may have changed
     # between backup and restore time.
-    VERSION=`docker exec ${ELAB_WEB_CONTAINER_NAME} bash -c 'echo $ELABFTW_VERSION'`
-    sed s/'image: elabftw\/elabimg:.*$'/"image: elabftw\/elabimg:$VERSION"/ "$CONF_FILE" > "$CONF_FILE.versioned"
+    ELABIMG_TAG=`docker exec ${ELAB_WEB_CONTAINER_NAME} bash -c 'echo $ELABFTW_VERSION'`
+    sed s/'image: elabftw\/elabimg:.*$'/"image: elabftw\/elabimg:$ELABIMG_TAG"/ "$CONF_FILE" > "$CONF_FILE.versioned"
     zip -rq "$zipfile" "$CONF_FILE.versioned"
     
     echo "Done. Copy ${BACKUP_DIR} over to another computer."


### PR DESCRIPTION
Branched from next, due to previous mistake!

Closing https://github.com/elabftw/elabctl/pull/24

--- Original comment.
The idea is that if the system is restored from a backup, it should get a somewhat faithful recreation of the system. Currently, the elabftw.yml will likely contain the image elabftw/elabimg:latest. This hack saves a copy with current version hard-coded instead. Restoring from backup should thus get a container that works with the SQL dump in the backup (which it might not if the elabftw/elabimg:latest code expects some other schema, or wants a superset of the current config to work reliably and securely).

The current pull request does not change the standard elabftw.yml file, but rather adds a copy.
