### PR TITLE
bug/minor: MySql: fix healthcheck crash

### DIFF
--- a/elabctl.sh
+++ b/elabctl.sh
@@ -562,7 +562,6 @@ function update-db-schema
             # check if healthcheck is available or else will crash (e.g with older versions of elabFTW config files)
             health_status=$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}no-healthcheck{{end}}' ${ELAB_MYSQL_CONTAINER_NAME})
             if [ "$health_status" == "healthy" ]; then
-                echo
                 break
             fi
             if [ "$health_status" == "no-healthcheck" ]; then

--- a/elabctl.sh
+++ b/elabctl.sh
@@ -556,11 +556,11 @@ function update-db-schema
 {
     is-installed
     # wait for mysql container to start, but only if there is one
-    if [ "$(docker ps | grep ${ELAB_MYSQL_CONTAINER_NAME})" ]; then
+    if docker ps | grep -q "${ELAB_MYSQL_CONTAINER_NAME}"; then
         echo -n "Waiting for the MySQL container to be ready before running update..."
         while true; do
-            # check if healthcheck is available or else will crash (e.g with older versions of elabFTW config files)
-            health_status=$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}no-healthcheck{{end}}' ${ELAB_MYSQL_CONTAINER_NAME})
+            # check if healthcheck is available or else will crash (e.g. with older versions of elabFTW config files)
+            health_status=$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}no-healthcheck{{end}}' "${ELAB_MYSQL_CONTAINER_NAME}")
             if [ "$health_status" == "healthy" ]; then
                 break
             fi


### PR DESCRIPTION
Fix #38 
update-db-schema fails to parse docker when mysql container has no healthcheck values.

- check if healthcheck is available before continuing. If not detectable, wait 20 seconds and retry.

- no healthcheck : 
![no-healthcheck](https://github.com/user-attachments/assets/558faa9d-0430-4edd-a065-3b98c687fb3b)

- waiting for mysql container :
![waiting](https://github.com/user-attachments/assets/4e105c77-1cb6-467a-b017-1581f6abed15)

- healthy
![Capture d’écran du 2024-12-12 11-31-56](https://github.com/user-attachments/assets/21424377-7317-45c7-b962-7602a3b4078d)

