### PR TITLE
add UPLOADS_DIR setting. See elabftw/elabftw#4795

### DIFF
--- a/elabctl.conf
+++ b/elabctl.conf
@@ -13,6 +13,10 @@
 # where do we store the MySQL database and the uploaded files?
 #declare DATA_DIR='/var/elabftw'
 
+# optional, set a different path for uploaded files
+# default is DATA_DIR/web
+#declare UPLOAD_DIR=/path/to/uploaded_files
+
 # name of the web container (default: elabftw)
 #declare ELAB_WEB_CONTAINER_NAME='elabftw'
 
@@ -47,6 +51,3 @@ declare BORG_KEEP_MONTHLY=6
 # optional, only set if required (rsync.net)
 #declare BORG_REMOTE_PATH=borg1
 
-# optional, set a different path for uploaded files
-# default is DATA_DIR/web
-#declare UPLOADS_DIR=/path/to/uploaded_files

--- a/elabctl.conf
+++ b/elabctl.conf
@@ -46,3 +46,7 @@ declare BORG_KEEP_MONTHLY=6
 
 # optional, only set if required (rsync.net)
 #declare BORG_REMOTE_PATH=borg1
+
+# optional, set a different path for uploaded files
+# default is DATA_DIR/web
+#declare UPLOADS_DIR=/path/to/uploaded_files

--- a/elabctl.sh
+++ b/elabctl.sh
@@ -23,6 +23,9 @@ declare ELABCTL_CONF_FILE="using default values (no config file found)"
 # will be overridden by select-dc-cmd()
 declare DC="docker compose"
 
+# allow override default web subfolder in data dir
+declare UPLOADS_DIR="${DATA_DIR}/web"
+
 function access-logs
 {
     docker logs "${ELAB_WEB_CONTAINER_NAME}" 2>/dev/null
@@ -58,7 +61,7 @@ function borg-backup
         export BORG_REMOTE_PATH="${BORG_REMOTE_PATH}"
     fi
     # we add to the borg the uploaded files (web directory) and also the backup dir containing dumps of MySQL
-    "${BORG_PATH}" create "::$(hostname)-$(date +%F_%H-%M)" "${DATA_DIR}/web" "${BACKUP_DIR}"
+    "${BORG_PATH}" create "::$(hostname)-$(date +%F_%H-%M)" "${UPLOADS_DIR}" "${BACKUP_DIR}"
     "${BORG_PATH}" prune --keep-daily="${BORG_KEEP_DAILY:-14}" --keep-monthly="${BORG_KEEP_MONTHLY:-6}"
 }
 

--- a/elabctl.sh
+++ b/elabctl.sh
@@ -328,7 +328,7 @@ function install
     # elab config
     echo 50 | dialog --backtitle "$backtitle" --title "$title" --gauge "Adjusting configuration" 20 80
     sed -i -e "s/SERVER_NAME=localhost/SERVER_NAME=$servername/" $TMP_CONF_FILE
-    sed -i -e "s:/var/elabftw:${DATA_DIR}:" $TMP_CONF_FILE
+    sed -i -e "s:/var/elabftw/web:${UPLOAD_DIR}:" $TMP_CONF_FILE
     sed -i -e "s/container_name: elabftw/container_name: ${ELAB_WEB_CONTAINER_NAME}/" $TMP_CONF_FILE
     sed -i -e "s/container_name: mysql/container_name: ${ELAB_MYSQL_CONTAINER_NAME}/" $TMP_CONF_FILE
 
@@ -512,6 +512,11 @@ function uninstall
         rm -vf "$CONF_FILE"
         echo "[x] Deleted $CONF_FILE"
     fi
+    # remove uploads directory
+    if [ -d "$UPLOAD_DIR" ]; then
+        sudo rm -rvf "$UPLOAD_DIR"
+        echo "[x] Deleted $UPLOAD_DIR"
+    fi
     # remove data directory
     if [ -d "$DATA_DIR" ]; then
         sudo rm -rvf "$DATA_DIR"
@@ -644,6 +649,13 @@ fi
 # check that the path for the data dir is absolute
 if [ "${DATA_DIR:0:1}" != "/" ]; then
     echo "Error in config file: DATA_DIR is not an absolute path!"
+    echo "Edit elabctl.conf and add a full path to the directory."
+    exit 1
+fi
+
+# check that the path for the upload dir is absolute
+if [ "${UPLOAD_DIR:0:1}" != "/" ]; then
+    echo "Error in config file: UPLOAD_DIR is not an absolute path!"
     echo "Edit elabctl.conf and add a full path to the directory."
     exit 1
 fi


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Upload directory is now configurable (previously hardcoded)
  * Borg backup remote path configuration option added

* **Improvements**
  * Backup, installation, and cleanup operations now respect the configured upload directory
  * Upload directory information displayed in system output
  * Path validation added to ensure upload directory uses absolute paths

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->