### PR TITLE
add BORG_PASSCOMMAND in backup function

### DIFF
--- a/elabctl.sh
+++ b/elabctl.sh
@@ -56,6 +56,7 @@ function borg-backup
     # add these into env so it is picked up by borg
     export BORG_REPO="${BORG_REPO}"
     export BORG_PASSPHRASE="${BORG_PASSPHRASE}"
+    export BORG_PASSCOMMAND="${BORG_PASSCOMMAND}"
     if [[ -v BORG_REMOTE_PATH ]]; then
         export BORG_REMOTE_PATH="${BORG_REMOTE_PATH}"
     fi


### PR DESCRIPTION
fix elabftw/elabftw#6252



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed environment variable propagation to ensure backup passcommand is properly available during backup operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->