### PR TITLE
Added borg compact to clean up and free disk space

### DIFF
--- a/elabctl.sh
+++ b/elabctl.sh
@@ -68,7 +68,7 @@ function borg-backup
     "${BORG_PATH}" create "::$(hostname)-$(date +%F_%H-%M)" "${UPLOAD_DIR}" "${BACKUP_DIR}"
     "${BORG_PATH}" prune --keep-daily="${BORG_KEEP_DAILY:-14}" --keep-monthly="${BORG_KEEP_MONTHLY:-6}"
     # run borg compact
-    "${BORG_PATH}" compact "${BACKUP_DIR}/borgbackup"
+    "${BORG_PATH}" compact "${BORG_REPO}"
 }
 
 # generate info for reporting a bug

--- a/elabctl.sh
+++ b/elabctl.sh
@@ -67,6 +67,8 @@ function borg-backup
     # we add to the borg the uploaded files (web directory) and also the backup dir containing dumps of MySQL
     "${BORG_PATH}" create "::$(hostname)-$(date +%F_%H-%M)" "${UPLOAD_DIR}" "${BACKUP_DIR}"
     "${BORG_PATH}" prune --keep-daily="${BORG_KEEP_DAILY:-14}" --keep-monthly="${BORG_KEEP_MONTHLY:-6}"
+    # run borg compact
+    "${BORG_PATH}" compact "${BACKUP_DIR}/borgbackup"
 }
 
 # generate info for reporting a bug


### PR DESCRIPTION
Added borg compact to clean up and free disk space. For more information, see: https://borgbackup.readthedocs.io/en/stable/usage/compact.html

Please make a pull request based on the `master` branch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved backup maintenance: automatic repository compaction now runs after pruning to reclaim space and improve backup performance and storage efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->