### PR TITLE
bug/minor: fix incorrect source path for local elactl.conf

### DIFF
--- a/elabctl.sh
+++ b/elabctl.sh
@@ -636,20 +636,20 @@ declare ELAB_MYSQL_CONTAINER_NAME='mysql'
 
 # Now we load the configuration file for custom directories set by user
 if [ -f /etc/elabctl.conf ]; then
-    source /etc/elabctl.conf
     ELABCTL_CONF_FILE="/etc/elabctl.conf"
+    source "${ELABCTL_CONF_FILE}"
 fi
 
 # elabctl.conf in ~/.config
 if [ -f "${HOME}/.config/elabctl.conf" ]; then
-    source "${HOME}/.config/elabctl.conf"
     ELABCTL_CONF_FILE="${HOME}/.config/elabctl.conf"
+    source "${ELABCTL_CONF_FILE}"
 fi
 
 # if elabctl is in current dir it has top priority
-if [ -f elabctl.conf ]; then
-    source elabctl.conf
-    ELABCTL_CONF_FILE="elabctl.conf"
+if [ -f "./elabctl.conf" ]; then
+    ELABCTL_CONF_FILE="./elabctl.conf"
+    source "${ELABCTL_CONF_FILE}"
 fi
 
 # check that the path for the data dir is absolute


### PR DESCRIPTION
fix #47
also avoid path duplication: source the variable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration file loading so the app consistently uses the correct config path.
  * Made local configuration overrides more reliable by loading them with safer path handling.
  * Reduced issues caused by inconsistent config detection across system, user, and current-directory locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->